### PR TITLE
[FIXES #8] Idempotent network requests

### DIFF
--- a/OGImage/OGImage.h
+++ b/OGImage/OGImage.h
@@ -6,8 +6,9 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "OGImageLoader.h"
 
-@interface OGImage : NSObject
+@interface OGImage : NSObject <OGImageLoaderDelegate>
 
 /**
  * Will asynchronously load the image at `url`, updating the `image` property

--- a/OGImage/OGImage.m
+++ b/OGImage/OGImage.m
@@ -29,17 +29,26 @@
     self.image = image;
 }
 
+#pragma mark - OGImageLoaderDelegate
+
+- (void)imageLoader:(OGImageLoader*)loader didLoadImage:(UIImage *)image forURL:(NSURL *)url {
+    NSParameterAssert([self.url isEqual:url]);
+    if (nil != image) {
+        [self imageDidLoadFromURL:image];
+    }
+}
+
+- (void)imageLoader:(OGImageLoader*)loader failedForURL:(NSURL *)url error:(NSError *)error {
+    NSParameterAssert([self.url isEqual:url]);
+    if (nil != error) {
+        [self _setError:error];
+    }
+}
+
 #pragma mark - Protected
 
 - (void)loadImageFromURL {
-    [[OGImageLoader shared] enqueueImageRequest:_url completionBlock:^(UIImage *image, NSError *error, NSTimeInterval loadTime) {
-        self.loadTime = loadTime;
-        if (nil != image) {
-            [self imageDidLoadFromURL:image];
-        } else if (nil != error) {
-            [self _setError:error];
-        }
-    }];
+    [[OGImageLoader shared] enqueueImageRequest:_url delegate:self];
 }
 
 - (void)_setError:(NSError *)error {

--- a/OGImage/OGImageLoader.h
+++ b/OGImage/OGImageLoader.h
@@ -11,6 +11,16 @@ extern const NSInteger OGImageLoadingError;
 
 extern NSString * const OGImageLoadingErrorDomain;
 
+@class OGImageLoader;
+@protocol OGImageLoaderDelegate <NSObject>
+
+@required
+
+- (void)imageLoader:(OGImageLoader*)loader didLoadImage:(UIImage *)image forURL:(NSURL *)url;
+- (void)imageLoader:(OGImageLoader*)loader failedForURL:(NSURL *)url error:(NSError *)error;
+
+@end
+
 typedef NS_ENUM(NSInteger, OGImageLoaderPriority) {
     OGImageLoaderPriority_Low,
     OGImageLoaderPriority_Default,
@@ -34,7 +44,7 @@ typedef void(^OGImageLoaderCompletionBlock)(UIImage *image, NSError *error, NSTi
  * Enqueues a request to load the image at `imageURL`. `completionBlock` will always
  * be called on the main queue.
  */
-- (void)enqueueImageRequest:(NSURL *)imageURL completionBlock:(OGImageLoaderCompletionBlock)completionBlock;
+- (void)enqueueImageRequest:(NSURL *)imageURL delegate:(id<OGImageLoaderDelegate>)delegate;
 
 /**
  * The maximum number of concurrent network requests that can be in-flight at

--- a/OGImage/OGImageLoader.m
+++ b/OGImage/OGImageLoader.m
@@ -32,6 +32,9 @@ static OGImageLoader * OGImageLoaderInstance;
     dispatch_source_t _timer;
     // A queue solely for file-loading work (e.g., when we get a `file:` or `assets-library:` URL)
     dispatch_queue_t _fileWorkQueue;
+    // key -> url, value -> NSArray of id<OGImageLoaderDelegate>
+    // we use this to track multiple interested parties on a single url
+    NSMutableDictionary *_loaderDelegates;
 }
 
 + (OGImageLoader *)shared {
@@ -54,6 +57,7 @@ static OGImageLoader * OGImageLoaderInstance;
         _imageCompletionQueue.maxConcurrentOperationCount = 1;
         _timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _requestsSerializationQueue);
         _fileWorkQueue = dispatch_queue_create("com.origamilabs.fileWorkQueue", DISPATCH_QUEUE_CONCURRENT);
+        _loaderDelegates = [NSMutableDictionary dictionaryWithCapacity:10];
         dispatch_source_set_event_handler(_timer, ^{
             [self checkForWork];
         });
@@ -68,10 +72,11 @@ static OGImageLoader * OGImageLoaderInstance;
     dispatch_suspend(_timer);
 }
 
-- (void)enqueueImageRequest:(NSURL *)imageURL completionBlock:(OGImageLoaderCompletionBlock)completionBlock {
+- (void)enqueueImageRequest:(NSURL *)imageURL delegate:(id<OGImageLoaderDelegate>)delegate {
     /**
      *
-     * What we basically have here is a LIFO queue (or stack, if you prefer) in `_requests` access to which
+     * What we basically have here is a LIFO queue (or stack, if you prefer) in `_requests`,
+     * access to which
      * is serialized by the serial dispatch queue `_requestsSerializationQueue`.
      * (The overloaded use of the term "queue" here is a possible source of confusion.
      * The former is a data structure, the latter is a GCD queue, used here in
@@ -103,7 +108,11 @@ static OGImageLoader * OGImageLoaderInstance;
                                         userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Couldn't load image from file URL:%@", @""), imageURL]}];
             }
             dispatch_async(dispatch_get_main_queue(), ^{
-                completionBlock(image, error, 0.);
+                if (nil == image) {
+                    [delegate imageLoader:self failedForURL:imageURL error:error];
+                } else {
+                    [delegate imageLoader:self didLoadImage:image forURL:imageURL];
+                }
             });
         });
         return;
@@ -121,7 +130,11 @@ static OGImageLoader * OGImageLoaderInstance;
                                             userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Couldn't load image from asset URL:%@", @""), imageURL]}];
                 }
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    completionBlock(image, error, 0.);
+                    if (nil == image) {
+                        [delegate imageLoader:self failedForURL:imageURL error:error];
+                    } else {
+                        [delegate imageLoader:self didLoadImage:image forURL:imageURL];
+                    }
                 });
             } failureBlock:^(NSError *origError) {
                 NSError *error = [NSError errorWithDomain:OGImageLoadingErrorDomain
@@ -129,22 +142,49 @@ static OGImageLoader * OGImageLoaderInstance;
                                                  userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Couldn't load image from asset URL:%@", @""), imageURL],
                                                             NSUnderlyingErrorKey : origError}];
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    completionBlock(nil, error, 0.);
+                    [delegate imageLoader:self failedForURL:imageURL error:error];
                 });
 
             }];
         });
         return;
     }
+
+    // it's a network url
     dispatch_async(_requestsSerializationQueue, ^{
         // serialize access to the request LIFO 'queue'
-        OGImageRequest *info = [[OGImageRequest alloc] initWithURL:imageURL completionBlock:^(UIImage *image, NSError *error, double timeElapsed){
+
+        // check to see if there's already an in-flight request for this url
+        NSMutableArray *lsnrs = [_loaderDelegates valueForKey:[imageURL absoluteString]];
+        if (nil != lsnrs) {
+            // we already have a request out for this url, so just add the
+            // loader delegate
+            [lsnrs addObject:delegate];
+            return;
+        }
+
+        // we don't have a request out for this url, so create it...
+        OGImageRequest *request = [[OGImageRequest alloc] initWithURL:imageURL completionBlock:^(UIImage *image, NSError *error, double timeElapsed){
             if (_inFlightRequestCount > 0) {
                 _inFlightRequestCount--;
             }
-            completionBlock(image, error, timeElapsed);
+            // when the request is complete, notify all interested delegates
+            NSMutableArray *lsnrs = _loaderDelegates[[imageURL absoluteString]];
+            for (id<OGImageLoaderDelegate> loaderDelegate in lsnrs) {
+                if (nil == image) {
+                    [loaderDelegate imageLoader:self failedForURL:imageURL error:error];
+                } else {
+                    [loaderDelegate imageLoader:self didLoadImage:image forURL:imageURL];
+                }
+            }
+            [_loaderDelegates removeObjectForKey:[imageURL absoluteString]];
         } queue:_imageCompletionQueue];
-        [_requests addObject:info];
+        [_requests addObject:request];
+
+        // ... and add the delegate to _loaderDelegates
+        lsnrs = [NSMutableArray arrayWithCapacity:3];
+        [lsnrs addObject:delegate];
+        _loaderDelegates[[imageURL absoluteString]] = lsnrs;
     });
 }
 

--- a/OGImageDemo/OGImageDemo.xcodeproj/project.pbxproj
+++ b/OGImageDemo/OGImageDemo.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		C8711462166410CD0015A743 /* OGImage.m in Sources */ = {isa = PBXBuildFile; fileRef = C882723D1663E5B0007D409F /* OGImage.m */; };
 		C8711465166417DE0015A743 /* OGImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = C8711464166417DE0015A743 /* OGImageLoader.m */; };
 		C8711466166417E20015A743 /* OGImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = C8711464166417DE0015A743 /* OGImageLoader.m */; };
+		C87C645F16C46C70006217C9 /* OGImageIdempotentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C87C645E16C46C70006217C9 /* OGImageIdempotentTests.m */; };
 		C88272191663DBDF007D409F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88272181663DBDF007D409F /* UIKit.framework */; };
 		C882721B1663DBDF007D409F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C882721A1663DBDF007D409F /* Foundation.framework */; };
 		C882721D1663DBDF007D409F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C882721C1663DBDF007D409F /* CoreGraphics.framework */; };
@@ -92,6 +93,7 @@
 		C871146016640F7D0015A743 /* OGImageAsyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OGImageAsyncTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		C8711463166417DE0015A743 /* OGImageLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = OGImageLoader.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		C8711464166417DE0015A743 /* OGImageLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OGImageLoader.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		C87C645E16C46C70006217C9 /* OGImageIdempotentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OGImageIdempotentTests.m; sourceTree = "<group>"; };
 		C88272141663DBDF007D409F /* OGImageDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OGImageDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C88272181663DBDF007D409F /* UIKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		C882721A1663DBDF007D409F /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -171,6 +173,7 @@
 				C8392EB1169CB38200F0907A /* OGImageAssetsLibraryTests.m */,
 				C871146016640F7D0015A743 /* OGImageAsyncTests.m */,
 				C8392EAF169CA21700F0907A /* OGImageFileTests.m */,
+				C87C645E16C46C70006217C9 /* OGImageIdempotentTests.m */,
 				C86E0BF01667FF9E006063B6 /* OGImageProcessingTests.m */,
 				C808967F1694ED01009BE21D /* OGImageTestsAppDelegate.h */,
 				C80896801694ED01009BE21D /* OGImageTestsAppDelegate.m */,
@@ -409,6 +412,7 @@
 				C80896811694ED01009BE21D /* OGImageTestsAppDelegate.m in Sources */,
 				C8392EB0169CA21700F0907A /* OGImageFileTests.m in Sources */,
 				C8392EB2169CB38200F0907A /* OGImageAssetsLibraryTests.m in Sources */,
+				C87C645F16C46C70006217C9 /* OGImageIdempotentTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OGImageDemo/OGImageTests/OGImageIdempotentTests.m
+++ b/OGImageDemo/OGImageTests/OGImageIdempotentTests.m
@@ -28,7 +28,9 @@ static NSString * const TEST_IMAGE_URL_STRING = @"http://easyquestion.net/thinka
     } else if (_image2 == object) {
         _image2Loaded = YES;
     }
-    [self notify:kGHUnitWaitStatusSuccess];
+    if (_image1Loaded && _image2Loaded) {
+        [self notify:kGHUnitWaitStatusSuccess];
+    }
 }
 
 - (void)testIdempotent {

--- a/OGImageDemo/OGImageTests/OGImageIdempotentTests.m
+++ b/OGImageDemo/OGImageTests/OGImageIdempotentTests.m
@@ -1,0 +1,44 @@
+//
+//  OGImageIdempotentTests.m
+//  OGImageDemo
+//
+//  Created by Art Gillespie on 2/7/13.
+//  Copyright (c) 2013 Origami Labs. All rights reserved.
+//
+
+#import "GHAsyncTestCase.h"
+#import "OGImage.h"
+
+static NSString * const TEST_IMAGE_URL_STRING = @"http://easyquestion.net/thinkagain/wp-content/uploads/2009/05/james-bond.jpg";
+
+@interface OGImageIdempotentTests : GHAsyncTestCase {
+    OGImage *_image1;
+    OGImage *_image2;
+    BOOL _image1Loaded;
+    BOOL _image2Loaded;
+}
+
+@end
+
+@implementation OGImageIdempotentTests
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+    if (_image1 == object) {
+        _image1Loaded = YES;
+    } else if (_image2 == object) {
+        _image2Loaded = YES;
+    }
+    [self notify:kGHUnitWaitStatusSuccess];
+}
+
+- (void)testIdempotent {
+    // we want to make sure that multiple requests for the same URL result in
+    // a single network request with notifications
+    [self prepare];
+    _image1 = [[OGImage alloc] initWithURL:[NSURL URLWithString:TEST_IMAGE_URL_STRING]];
+    [_image1 addObserver:self forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:nil];
+    _image2 = [[OGImage alloc] initWithURL:[NSURL URLWithString:TEST_IMAGE_URL_STRING]];
+    [_image2 addObserver:self forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:nil];
+    [self waitForStatus:kGHUnitWaitStatusSuccess timeout:15.f];
+}
+@end


### PR DESCRIPTION
Multiple requests for the same URL will now only result in a single network request. No changes to the `OGImage` and subclasses' interfaces. Changed the interface to `OGImageLoader`
