### PR TITLE
[FIXES #9]

### DIFF
--- a/OGImage/OGImageProcessing.h
+++ b/OGImage/OGImageProcessing.h
@@ -7,6 +7,17 @@
 
 #import <Foundation/Foundation.h>
 
+@class OGImageProcessing;
+
+@protocol OGImageProcessingDelegate
+
+@required
+
+- (void)imageProcessing:(OGImageProcessing *)processing didProcessImage:(UIImage *)image;
+- (void)imageProcessingFailed:(OGImageProcessing *)processing error:(NSError *)error;
+
+@end
+
 typedef void (^OGImageProcessingBlock)(UIImage *image, NSError *error);
 
 extern NSString * const OGImageProcessingErrorDomain;
@@ -27,8 +38,8 @@ typedef NS_ENUM(NSInteger, OGImageProcessingScaleMethod) {
 /**
  * Scale `image` to `size` using aspect fit. Note `size` is specified in points.
  */
-- (void)scaleImage:(UIImage *)image toSize:(CGSize)size cornerRadius:(CGFloat)cornerRadius completionBlock:(OGImageProcessingBlock)block;
+- (void)scaleImage:(UIImage *)image toSize:(CGSize)size cornerRadius:(CGFloat)cornerRadius delegate:(id<OGImageProcessingDelegate>)delegate;
 
-- (void)scaleImage:(UIImage *)image toSize:(CGSize)size cornerRadius:(CGFloat)cornerRadius method:(OGImageProcessingScaleMethod)method completionBlock:(OGImageProcessingBlock)block;
+- (void)scaleImage:(UIImage *)image toSize:(CGSize)size cornerRadius:(CGFloat)cornerRadius method:(OGImageProcessingScaleMethod)method delegate:(id<OGImageProcessingDelegate>)delegate;
 
 @end

--- a/OGImage/OGScaledImage.h
+++ b/OGImage/OGScaledImage.h
@@ -8,7 +8,7 @@
 #import "OGCachedImage.h"
 #import "OGImageProcessing.h"
 
-@interface OGScaledImage : OGCachedImage
+@interface OGScaledImage : OGCachedImage <OGImageProcessingDelegate>
 
 /**
  * Scale the image at `url` to aspect-fit into `size` (specified in points). Note

--- a/OGImage/OGScaledImage.m
+++ b/OGImage/OGScaledImage.m
@@ -89,14 +89,18 @@ NSString *OGKeyWithSize(NSString *origKey, CGSize size) {
 }
 
 - (void)doScaleImage:(UIImage *)image {
-    [[OGImageProcessing shared] scaleImage:image toSize:_scaledSize cornerRadius:_cornerRadius method:_method completionBlock:^(UIImage *image, NSError *error) {
-        if (nil != error) {
-            self.error = error;
-        } else {
-            self.scaledImage = image;
-            [[OGImageCache shared] setImage:image forKey:_scaledKey];
-        }
-    }];
+    [[OGImageProcessing shared] scaleImage:image toSize:_scaledSize cornerRadius:_cornerRadius method:_method delegate:self];
+}
+
+#pragma mark - OGImageProcessingDelegate
+
+- (void)imageProcessing:(OGImageProcessing *)processing didProcessImage:(UIImage *)image {
+    self.scaledImage = image;
+    [[OGImageCache shared] setImage:image forKey:_scaledKey];
+}
+
+- (void)imageProcessingFailed:(OGImageProcessing *)processing error:(NSError *)error {
+    self.error = error;
 }
 
 @end


### PR DESCRIPTION
If multiple requests for the same image processing combination are made (image + size + cornerRadius), only queue up one actual processing request and simply notify the callers. This doesn't change the interface or behavior of `OGScaledImage`
