### PR TITLE
Enhancement 17 - Be smart about file type/alpha channel

### DIFF
--- a/OGImage/OGCachedImage.m
+++ b/OGImage/OGCachedImage.m
@@ -31,7 +31,7 @@
 }
 
 - (void)loadImageFromURL {
-    [[OGImageCache shared] imageForKey:_key block:^(UIImage *image) {
+    [[OGImageCache shared] imageForKey:_key block:^(__OGImage *image) {
         if (nil == image) {
             [super loadImageFromURL];
         } else {
@@ -40,7 +40,7 @@
     }];
 }
 
-- (void)imageDidLoadFromURL:(UIImage *)image {
+- (void)imageDidLoadFromURL:(__OGImage *)image {
     [[OGImageCache shared] setImage:image forKey:_key];
     [super imageDidLoadFromURL:image];
 }

--- a/OGImage/OGImage.h
+++ b/OGImage/OGImage.h
@@ -73,6 +73,9 @@
  * Original image metadata dictionary. This is the same dictionary returned by `CGImageSourceCopyProperties`
  * See
  * https://developer.apple.com/library/ios/documentation/GraphicsImaging/Conceptual/ImageIOGuide/imageio_source/ikpg_source.html#//apple_ref/doc/uid/TP40005462-CH218-DontLinkElementID_8
+ *
+ * (If you're loading an `assets-library://` URL instead of an image file from the network or file system,
+ * this will have the dictionary from `ALAssetRepresentation.metadata`)
  */
 @property (nonatomic, readonly) NSDictionary *info;
 

--- a/OGImage/OGImage.h
+++ b/OGImage/OGImage.h
@@ -44,7 +44,7 @@
  *
  * This method will always be called on the main queue.
  */
-- (void)imageDidLoadFromURL:(UIImage *)image;
+- (void)imageDidLoadFromURL:(__OGImage *)image;
 
 /**
  * Subclasses can override this method to check caches, etc., before initiating
@@ -63,6 +63,23 @@
  * error occurs.
  */
 @property (nonatomic, strong) UIImage *image;
+
+/**
+ * Original image type UTI, e.g., public.jpeg, public.png
+ */
+@property (nonatomic, readonly) NSString *type;
+
+/**
+ * Original image metadata dictionary. This is the same dictionary returned by `CGImageSourceCopyProperties`
+ * See
+ * https://developer.apple.com/library/ios/documentation/GraphicsImaging/Conceptual/ImageIOGuide/imageio_source/ikpg_source.html#//apple_ref/doc/uid/TP40005462-CH218-DontLinkElementID_8
+ */
+@property (nonatomic, readonly) NSDictionary *info;
+
+/**
+ * Original image's alpha info.
+ */
+@property (nonatomic, readonly) CGImageAlphaInfo alphaInfo;
 
 /**
  * Observe this property to be notified if there was an error loading the image.

--- a/OGImage/OGImage.m
+++ b/OGImage/OGImage.m
@@ -9,11 +9,7 @@
 #import "OGImageLoader.h"
 #import "__OGImage.h"
 
-@implementation OGImage {
-    NSString *_type;
-    NSDictionary *_info;
-    CGImageAlphaInfo _alphaInfo;
-}
+@implementation OGImage
 
 - (id)initWithURL:(NSURL *)url {
     return [self initWithURL:url placeholderImage:nil];

--- a/OGImage/OGImage.m
+++ b/OGImage/OGImage.m
@@ -7,8 +7,13 @@
 
 #import "OGImage.h"
 #import "OGImageLoader.h"
+#import "__OGImage.h"
 
-@implementation OGImage
+@implementation OGImage {
+    NSString *_type;
+    NSDictionary *_info;
+    CGImageAlphaInfo _alphaInfo;
+}
 
 - (id)initWithURL:(NSURL *)url {
     return [self initWithURL:url placeholderImage:nil];
@@ -35,13 +40,13 @@
     [self removeObserver:observer forKeyPath:@"error"];
 }
 
-- (void)imageDidLoadFromURL:(UIImage *)image {
+- (void)imageDidLoadFromURL:(__OGImage *)image {
     self.image = image;
 }
 
 #pragma mark - OGImageLoaderDelegate
 
-- (void)imageLoader:(OGImageLoader*)loader didLoadImage:(UIImage *)image forURL:(NSURL *)url {
+- (void)imageLoader:(OGImageLoader*)loader didLoadImage:(__OGImage *)image forURL:(NSURL *)url {
     NSParameterAssert([self.url isEqual:url]);
     if (nil != image) {
         [self imageDidLoadFromURL:image];
@@ -53,6 +58,18 @@
     if (nil != error) {
         [self _setError:error];
     }
+}
+
+- (NSString *)type {
+    return ((__OGImage *)_image).originalFileType;
+}
+
+- (NSDictionary *)info {
+    return ((__OGImage *)_image).originalFileProperties;
+}
+
+- (CGImageAlphaInfo)alphaInfo {
+    return ((__OGImage *)_image).originalFileAlphaInfo;
 }
 
 #pragma mark - Protected

--- a/OGImage/OGImageCache.h
+++ b/OGImage/OGImageCache.h
@@ -7,14 +7,9 @@
 
 #import <Foundation/Foundation.h>
 
-@class OGImage;
+@class __OGImage;
 
-typedef void (^OGImageCacheCompletionBlock)(UIImage *image);
-
-typedef NS_ENUM(NSInteger, OGImageFileFormat) {
-    OGImageFileFormatJPEG,
-    OGImageFileFormatPNG
-};
+typedef void (^OGImageCacheCompletionBlock)(__OGImage *image);
 
 @interface OGImageCache : NSObject
 
@@ -31,15 +26,7 @@ typedef NS_ENUM(NSInteger, OGImageFileFormat) {
  */
 - (void)imageForKey:(NSString *)key block:(OGImageCacheCompletionBlock)block;
 
-/**
- * Store `image` in-memory and on disk. Image will be serialized as PNG.
- */
-- (void)setImage:(UIImage *)image forKey:(NSString *)key;
-
-/**
- * Store `image` in-memory and on disk. Image will be serialized as `format`.
- */
-- (void)setImage:(UIImage *)image forKey:(NSString *)key format:(OGImageFileFormat)format;
+- (void)setImage:(__OGImage *)image forKey:(NSString *)key;
 
 /**
  * Remove all cached images from in-memory and on-disk caches. If `wait` is `YES`

--- a/OGImage/OGImageCache.m
+++ b/OGImage/OGImageCache.m
@@ -8,6 +8,7 @@
 #import "OGImageCache.h"
 #import "OGImage.h"
 #import <CommonCrypto/CommonDigest.h>
+#import <ImageIO/ImageIO.h>
 
 static OGImageCache *OGImageCacheShared;
 
@@ -65,7 +66,7 @@ NSString *OGImageCachePath() {
 - (void)imageForKey:(NSString *)key block:(OGImageCacheCompletionBlock)block {
     NSParameterAssert(nil != key);
     NSParameterAssert(nil != block);
-    UIImage *image = [_memoryCache objectForKey:key];
+    __OGImage *image = [_memoryCache objectForKey:key];
     if (nil != image) {
         block(image);
         return;
@@ -73,14 +74,7 @@ NSString *OGImageCachePath() {
     dispatch_async(_cacheFileTasksQueue, ^{
         // Check to see if the image is cached locally
         NSString *cachePath = [OGImageCache filePathForKey:(key)];
-        UIImage *image = nil;
-        if ([[NSFileManager defaultManager] fileExistsAtPath:cachePath]) {
-            NSData *data = [NSData dataWithContentsOfFile:cachePath];
-            // we assume here that we cached images at the same scale as the device
-            // which makes sense, though there may be cases in the simulator where
-            // you get images at the wrong scale.
-            image = [UIImage imageWithData:data scale:[UIScreen mainScreen].scale];
-        }
+        __OGImage *image = [[__OGImage alloc] initWithDataAtURL:[NSURL fileURLWithPath:cachePath]];
         // if we have the image in the on-disk cache, store it to the in-memory cache
         if (nil != image) {
             [_memoryCache setObject:image forKey:key];
@@ -92,30 +86,17 @@ NSString *OGImageCachePath() {
     });
 }
 
-- (void)setImage:(UIImage *)image forKey:(NSString *)key {
+- (void)setImage:(__OGImage *)image forKey:(NSString *)key {
     NSParameterAssert(nil != image);
     NSParameterAssert(nil != key);
     [_memoryCache setObject:image forKey:key];
     dispatch_async(_cacheFileTasksQueue, ^{
-        NSString *cachePath = [OGImageCache filePathForKey:(key)];
-        NSData *imgData = UIImagePNGRepresentation(image);
-        [imgData writeToFile:cachePath atomically:YES];
-    });
-}
-
-- (void)setImage:(UIImage *)image forKey:(NSString *)key format:(OGImageFileFormat)format {
-    NSParameterAssert(nil != image);
-    NSParameterAssert(nil != key);
-    [_memoryCache setObject:image forKey:key];
-    dispatch_async(_cacheFileTasksQueue, ^{
-        NSString *cachePath = [OGImageCache filePathForKey:key];
-        NSData *imgData = nil;
-        if (OGImageFileFormatJPEG == format) {
-            imgData = UIImageJPEGRepresentation(image, 5);
-        } else {
-            imgData = UIImagePNGRepresentation(image);
+        NSURL *fileURL = [NSURL fileURLWithPath:[OGImageCache filePathForKey:key]];
+        NSError *error;
+        if(![image writeToURL:fileURL error:&error]) {
+            NSLog(@"[OGImageCache ERROR] failed to write image with error %@ %s %d", error, __FILE__, __LINE__);
+            return;
         }
-        [imgData writeToFile:cachePath atomically:YES];
     });
 }
 

--- a/OGImage/OGImageLoader.h
+++ b/OGImage/OGImageLoader.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "__OGImage.h"
 
 extern const NSInteger OGImageLoadingError;
 
@@ -16,7 +17,7 @@ extern NSString * const OGImageLoadingErrorDomain;
 
 @required
 
-- (void)imageLoader:(OGImageLoader*)loader didLoadImage:(UIImage *)image forURL:(NSURL *)url;
+- (void)imageLoader:(OGImageLoader*)loader didLoadImage:(__OGImage *)image forURL:(NSURL *)url;
 - (void)imageLoader:(OGImageLoader*)loader failedForURL:(NSURL *)url error:(NSError *)error;
 
 @end
@@ -31,7 +32,7 @@ typedef NS_ENUM(NSInteger, OGImageLoaderPriority) {
  * This block is called when an image is loaded or fails to load. If `error` is
  * nil, `image` should be valid.
  */
-typedef void(^OGImageLoaderCompletionBlock)(UIImage *image, NSError *error, NSTimeInterval loadTime);
+typedef void(^OGImageLoaderCompletionBlock)(__OGImage *image, NSError *error, NSTimeInterval loadTime);
 
 @interface OGImageLoader : NSObject
 

--- a/OGImage/OGImageLoader.m
+++ b/OGImage/OGImageLoader.m
@@ -124,7 +124,7 @@ static OGImageLoader * OGImageLoaderInstance;
                 ALAssetRepresentation *jpg = [asset representationForUTI:@"public.jpeg"];
                 CGImageRef jpgImage = jpg.fullResolutionImage;
                 CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(jpgImage);
-                __OGImage *image = [[__OGImage alloc] initWithCGImage:jpg.fullResolutionImage type:@"public.jpeg" info:jpg.metadata alphaInfo:alphaInfo scale:jpg.scale orientation:jpg.orientation];
+                __OGImage *image = [[__OGImage alloc] initWithCGImage:jpg.fullResolutionImage type:@"public.jpeg" info:jpg.metadata alphaInfo:alphaInfo scale:jpg.scale orientation:(UIImageOrientation)jpg.orientation];
                 NSError *error = nil;
                 if (nil == image) {
                     error = [NSError errorWithDomain:OGImageLoadingErrorDomain

--- a/OGImage/OGImageLoader.m
+++ b/OGImage/OGImageLoader.m
@@ -100,7 +100,8 @@ static OGImageLoader * OGImageLoaderInstance;
     // if this is a file:// or assets-library:// URL, don't bother with a OGImageRequest
     if ([[imageURL scheme] isEqualToString:@"file"]) {
         dispatch_async(_fileWorkQueue, ^{
-            UIImage *image = [UIImage imageWithContentsOfFile:[imageURL path]];
+            NSData *data = [NSData dataWithContentsOfURL:imageURL];
+            __OGImage *image = [[__OGImage alloc] initWithData:data];
             NSError *error = nil;
             if (nil == image) {
                 error = [NSError errorWithDomain:OGImageLoadingErrorDomain
@@ -120,9 +121,10 @@ static OGImageLoader * OGImageLoaderInstance;
         dispatch_async(_fileWorkQueue, ^{
             ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
             [library assetForURL:imageURL resultBlock:^(ALAsset *asset) {
-                // TODO: [alg] be smart about orientation and scale
-                NSNumber *orientation = [asset valueForProperty:ALAssetPropertyOrientation];
-                UIImage *image = [UIImage imageWithCGImage:asset.defaultRepresentation.fullResolutionImage scale:1.f orientation:[orientation intValue]];
+                ALAssetRepresentation *jpg = [asset representationForUTI:@"public.jpeg"];
+                CGImageRef jpgImage = jpg.fullResolutionImage;
+                CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(jpgImage);
+                __OGImage *image = [[__OGImage alloc] initWithCGImage:jpg.fullResolutionImage type:@"public.jpeg" info:jpg.metadata alphaInfo:alphaInfo scale:jpg.scale orientation:jpg.orientation];
                 NSError *error = nil;
                 if (nil == image) {
                     error = [NSError errorWithDomain:OGImageLoadingErrorDomain
@@ -164,7 +166,8 @@ static OGImageLoader * OGImageLoaderInstance;
         }
 
         // we don't have a request out for this url, so create it...
-        OGImageRequest *request = [[OGImageRequest alloc] initWithURL:imageURL completionBlock:^(UIImage *image, NSError *error, double timeElapsed){
+        OGImageRequest *request = [[OGImageRequest alloc] initWithURL:imageURL
+                                                      completionBlock:^(__OGImage *image, NSError *error, double timeElapsed){
             if (_inFlightRequestCount > 0) {
                 _inFlightRequestCount--;
             }

--- a/OGImage/OGImageProcessing.h
+++ b/OGImage/OGImageProcessing.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "__OGImage.h"
 
 @class OGImageProcessing;
 
@@ -13,12 +14,10 @@
 
 @required
 
-- (void)imageProcessing:(OGImageProcessing *)processing didProcessImage:(UIImage *)image;
+- (void)imageProcessing:(OGImageProcessing *)processing didProcessImage:(__OGImage *)image;
 - (void)imageProcessingFailed:(OGImageProcessing *)processing error:(NSError *)error;
 
 @end
-
-typedef void (^OGImageProcessingBlock)(UIImage *image, NSError *error);
 
 extern NSString * const OGImageProcessingErrorDomain;
 
@@ -38,8 +37,8 @@ typedef NS_ENUM(NSInteger, OGImageProcessingScaleMethod) {
 /**
  * Scale `image` to `size` using aspect fit. Note `size` is specified in points.
  */
-- (void)scaleImage:(UIImage *)image toSize:(CGSize)size cornerRadius:(CGFloat)cornerRadius delegate:(id<OGImageProcessingDelegate>)delegate;
+- (void)scaleImage:(__OGImage *)image toSize:(CGSize)size cornerRadius:(CGFloat)cornerRadius delegate:(id<OGImageProcessingDelegate>)delegate;
 
-- (void)scaleImage:(UIImage *)image toSize:(CGSize)size cornerRadius:(CGFloat)cornerRadius method:(OGImageProcessingScaleMethod)method delegate:(id<OGImageProcessingDelegate>)delegate;
+- (void)scaleImage:(__OGImage *)image toSize:(CGSize)size cornerRadius:(CGFloat)cornerRadius method:(OGImageProcessingScaleMethod)method delegate:(id<OGImageProcessingDelegate>)delegate;
 
 @end

--- a/OGImage/OGImageRequest.m
+++ b/OGImage/OGImageRequest.m
@@ -7,6 +7,7 @@
 //
 
 #import "OGImageRequest.h"
+#import <ImageIO/ImageIO.h>
 
 @implementation OGImageRequest {
     NSDate *_startTime;
@@ -62,14 +63,14 @@
 }
 
 - (void)prepareImageAndNotify {
-    UIImage *tmpImage = nil;
+    __OGImage *tmpImage = nil;
     NSError *tmpError = nil;
     if (200 == _httpResponse.statusCode) {
         if (nil != _data) {
-            tmpImage = [UIImage imageWithData:_data];
+            tmpImage = [[__OGImage alloc] initWithData:_data];
             if (nil == tmpImage) {
                 // data isn't nil, but we couldn't create an image out of it...
-                tmpError = [NSError errorWithDomain:NSCocoaErrorDomain code:OGImageLoadingError userInfo:@{NSLocalizedDescriptionKey : @"OGImage: Received data from url, but couldn't create UIImage instance"}];
+                tmpError = [NSError errorWithDomain:NSCocoaErrorDomain code:OGImageLoadingError userInfo:@{NSLocalizedDescriptionKey : @"OGImage: Received data from url, but couldn't create __OGImage instance"}];
             }
         }
     } else {

--- a/OGImage/OGScaledImage.h
+++ b/OGImage/OGScaledImage.h
@@ -34,17 +34,17 @@
 /**
  * Scale the given image to `size` and cache it at `key`
  */
-- (id)initWithImage:(UIImage *)image size:(CGSize)size key:(NSString *)key;
+- (id)initWithImage:(__OGImage *)image size:(CGSize)size key:(NSString *)key;
 
 /**
  * Scale the given image to `size` using `method` and cache it at `key`
  */
-- (id)initWithImage:(UIImage *)image size:(CGSize)size method:(OGImageProcessingScaleMethod)method key:(NSString *)key;
+- (id)initWithImage:(__OGImage *)image size:(CGSize)size method:(OGImageProcessingScaleMethod)method key:(NSString *)key;
 
 /**
  * Scale the given image to `size` with a rounded rect mask specified by `cornerRadius` using `method` and cache it at `key`
  */
-- (id)initWithImage:(UIImage *)image size:(CGSize)size cornerRadius:(CGFloat)cornerRadius method:(OGImageProcessingScaleMethod)method key:(NSString *)key;
+- (id)initWithImage:(__OGImage *)image size:(CGSize)size cornerRadius:(CGFloat)cornerRadius method:(OGImageProcessingScaleMethod)method key:(NSString *)key;
 
 /**
  * Equivalent to adding an observer for @"image", @"scaledImage", & @"error"

--- a/OGImage/OGScaledImage.m
+++ b/OGImage/OGScaledImage.m
@@ -51,15 +51,15 @@ NSString *OGKeyWithSize(NSString *origKey, CGSize size, CGFloat cornerRadius) {
     return self;
 }
 
-- (id)initWithImage:(UIImage *)image size:(CGSize)size key:(NSString *)key {
+- (id)initWithImage:(__OGImage *)image size:(CGSize)size key:(NSString *)key {
     return [self initWithImage:image size:size method:OGImageProcessingScale_AspectFit key:key];
 }
 
-- (id)initWithImage:(UIImage *)image size:(CGSize)size method:(OGImageProcessingScaleMethod)method key:(NSString *)key {
+- (id)initWithImage:(__OGImage *)image size:(CGSize)size method:(OGImageProcessingScaleMethod)method key:(NSString *)key {
     return [self initWithImage:image size:size cornerRadius:0.f method:method key:key];
 }
 
-- (id)initWithImage:(UIImage *)image size:(CGSize)size cornerRadius:(CGFloat)cornerRadius method:(OGImageProcessingScaleMethod)method key:(NSString *)key {
+- (id)initWithImage:(__OGImage *)image size:(CGSize)size cornerRadius:(CGFloat)cornerRadius method:(OGImageProcessingScaleMethod)method key:(NSString *)key {
     NSParameterAssert(nil != key);
     self = [super init];
     if (nil != self) {
@@ -68,7 +68,7 @@ NSString *OGKeyWithSize(NSString *origKey, CGSize size, CGFloat cornerRadius) {
         _scaledKey = key;
         _cornerRadius = cornerRadius;
         self.image = image;
-        [self doScaleImage:self.image];
+        [self doScaleImage:(__OGImage *)self.image];
     }
     return self;
 }

--- a/OGImage/OGScaledImage.m
+++ b/OGImage/OGScaledImage.m
@@ -8,8 +8,8 @@
 #import "OGScaledImage.h"
 #import "OGImageCache.h"
 
-NSString *OGKeyWithSize(NSString *origKey, CGSize size) {
-    return [NSString stringWithFormat:@"%@-%f-%f", origKey, size.width, size.height];
+NSString *OGKeyWithSize(NSString *origKey, CGSize size, CGFloat cornerRadius) {
+    return [NSString stringWithFormat:@"%@-%f-%f-%f", origKey, size.width, size.height, cornerRadius];
 }
 
 @implementation OGScaledImage {
@@ -44,8 +44,8 @@ NSString *OGKeyWithSize(NSString *origKey, CGSize size) {
         self.url = url;
         self.scaledImage = placeholderImage;
         _scaledSize = size;
-        _scaledKey = OGKeyWithSize(self.key, _scaledSize);
         _cornerRadius = cornerRadius;
+        _scaledKey = OGKeyWithSize(self.key, _scaledSize, _cornerRadius);
         [self loadImageFromURL];
     }
     return self;
@@ -84,7 +84,7 @@ NSString *OGKeyWithSize(NSString *origKey, CGSize size) {
 }
 
 - (void)loadImageFromURL {
-    [[OGImageCache shared] imageForKey:_scaledKey block:^(UIImage *image) {
+    [[OGImageCache shared] imageForKey:_scaledKey block:^(__OGImage *image) {
         if (nil == image) {
             [super loadImageFromURL];
         } else {
@@ -93,18 +93,18 @@ NSString *OGKeyWithSize(NSString *origKey, CGSize size) {
     }];
 }
 
-- (void)imageDidLoadFromURL:(UIImage *)image {
+- (void)imageDidLoadFromURL:(__OGImage *)image {
     [super imageDidLoadFromURL:image];
     [self doScaleImage:image];
 }
 
-- (void)doScaleImage:(UIImage *)image {
-    [[OGImageProcessing shared] scaleImage:image toSize:_scaledSize cornerRadius:_cornerRadius method:_method delegate:self];
+- (void)doScaleImage:(__OGImage *)image {
+    [[OGImageProcessing shared] scaleImage:(__OGImage *)image toSize:_scaledSize cornerRadius:_cornerRadius method:_method delegate:self];
 }
 
 #pragma mark - OGImageProcessingDelegate
 
-- (void)imageProcessing:(OGImageProcessing *)processing didProcessImage:(UIImage *)image {
+- (void)imageProcessing:(OGImageProcessing *)processing didProcessImage:(__OGImage *)image {
     self.scaledImage = image;
     [[OGImageCache shared] setImage:image forKey:_scaledKey];
 }

--- a/OGImage/__OGImage.h
+++ b/OGImage/__OGImage.h
@@ -1,0 +1,62 @@
+//
+//  __OGImage.h
+//  OGImageDemo
+//
+//  Created by Art Gillespie on 2/8/13.
+//  art@origami.com
+//  Copyright (c) 2013 Origami Labs. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+/**
+ * Note the underscores in the name of this class: It's intended for internal use only.
+ *
+ * This is a simple subclass of `UIImage` that lets us pass around some additional
+ * information (original file type, metadata, alpha info) and provides some
+ * convenience methods for saving/loading.
+ *
+ * When you create an __OGImage with a fileURL or NSData instance, it uses the
+ * Image I/O framework under the hood to find out about the file's format, metadata
+ * and alpha. Additionally, if the file ends with the extension `.@2x`, __OGImage
+ * will set UIImage's `scale` property correctly.
+ *
+ * When you save an __OGImage using `writeToURL`, it will automatically choose
+ * the best format based on the current alpha properties and original file format.
+ * Additionally, if the superclass' property `scale` is `2.f`, `writeToURL` will
+ * automatically append the `.@2x` suffix. (Ultimately, this `.@2x` stuff is
+ * an implementation detail: If you're not worried about cache internals, you
+ * don't need to worry about this. Just use keys normally and `__OGImage` and
+ * friends will figure everything out for you.
+ */
+
+@interface __OGImage : UIImage
+
+/**
+ * Given a file URL, this will use Image I/O to load the file and populate the
+ * `originalFileType`, `originalFileProperties` and `originalFileAlphaInfo` properties.
+ * Additionally, if there's scale info in the file, this will set `scale` correctly.
+ */
+- (id)initWithDataAtURL:(NSURL *)url;
+
+/**
+ * Given an `NSData` instance, this will use Image I/O to load the data and populate the `originalFile**`
+ * properties.
+ */
+- (id)initWithData:(NSData *)data scale:(CGFloat)scale;
+
+- (id)initWithCGImage:(CGImageRef)image type:(NSString *)type info:(NSDictionary *)info alphaInfo:(CGImageAlphaInfo)alphaInfo;
+
+- (id)initWithCGImage:(CGImageRef)image type:(NSString *)type info:(NSDictionary *)info alphaInfo:(CGImageAlphaInfo)alphaInfo scale:(CGFloat)scale orientation:(UIImageOrientation)orientation;
+
+- (BOOL)writeToURL:(NSURL *)url error:(NSError **)error;
+
+@property (nonatomic, readonly) NSString *originalFileType;
+
+@property (nonatomic, readonly) NSDictionary *originalFileProperties;
+
+@property (nonatomic, readonly) CGImageAlphaInfo originalFileAlphaInfo;
+
+@property (nonatomic, readonly) CGImageAlphaInfo alphaInfo;
+
+@end

--- a/OGImage/__OGImage.m
+++ b/OGImage/__OGImage.m
@@ -95,7 +95,9 @@ NSString * const OGImageInfoScaleKey = @"OGImageInfoScaleKey";
     }
     CGImageDestinationRef imageDestination = CGImageDestinationCreateWithURL((__bridge CFURLRef)fileURL, (__bridge CFStringRef)imgType, 1, NULL);
     if (NULL == imageDestination) {
-        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:-255 userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:@"[OGImageCache ERROR] failed to created image destination %s %d", __FILE__, __LINE__]}];
+        if (nil != error) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:-255 userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:@"[OGImageCache ERROR] failed to created image destination %s %d", __FILE__, __LINE__]}];
+        }
         return NO;
     }
     CGImageDestinationAddImage(imageDestination, self.CGImage, (__bridge CFDictionaryRef)_originalFileProperties);

--- a/OGImage/__OGImage.m
+++ b/OGImage/__OGImage.m
@@ -1,0 +1,107 @@
+//
+//  __OGImage.m
+//  OGImageDemo
+//
+//  Created by Art Gillespie on 2/8/13.
+//  Copyright (c) 2013 Origami Labs. All rights reserved.
+//
+
+#import "__OGImage.h"
+#import <ImageIO/ImageIO.h>
+
+NSString * const OGImageInfoKey = @"OGImageInfoKey";
+NSString * const OGImageInfoScaleKey = @"OGImageInfoScaleKey";
+
+@implementation __OGImage
+
+- (id)initWithDataAtURL:(NSURL *)url {
+    CGFloat scale = 1.f;
+    if (NO == [[NSFileManager defaultManager] fileExistsAtPath:[url path]]) {
+        url = [url URLByAppendingPathExtension:@"@2x"];
+        if (NO == [[NSFileManager defaultManager] fileExistsAtPath:[url path]]) {
+            // no such file
+            return nil;
+        }
+        scale = 2.f;
+    }
+    NSData *data = [NSData dataWithContentsOfURL:url];
+    return [self initWithData:data scale:scale];
+}
+
+- (id)initWithCGImage:(CGImageRef)image type:(NSString *)type info:(NSDictionary *)info alphaInfo:(CGImageAlphaInfo)alphaInfo scale:(CGFloat)scale orientation:(UIImageOrientation)orientation {
+    self = [super initWithCGImage:image scale:scale orientation:orientation];
+    if (nil != self) {
+        _originalFileType = type;
+        _originalFileProperties = info;
+        _originalFileAlphaInfo = alphaInfo;
+    }
+    return self;
+}
+
+- (id)initWithCGImage:(CGImageRef)image type:(NSString *)type info:(NSDictionary *)info alphaInfo:(CGImageAlphaInfo)alphaInfo {
+    self = [super initWithCGImage:image];
+    if (nil != self) {
+        _originalFileType = type;
+        _originalFileProperties = info;
+        _originalFileAlphaInfo = alphaInfo;
+    }
+    return self;
+}
+
+- (id)initWithData:(NSData *)data scale:(CGFloat)scale {
+    if (nil == data)
+        return nil;
+
+    CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    if (NULL == imageSource) {
+        // data isn't nil, but we couldn't create an image out of it...
+        return nil;
+    } else {
+        CGImageRef cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
+        if (NULL == cgImage) {
+            CFRelease(imageSource);
+            return nil;
+        } else {
+            _originalFileProperties = CFBridgingRelease(CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil));
+            // do we have an OGImageDictionary?
+            _originalFileType = (__bridge NSString *)CGImageSourceGetType(imageSource);
+            _originalFileAlphaInfo = CGImageGetAlphaInfo(cgImage);
+            self = [super initWithCGImage:cgImage scale:scale orientation:UIImageOrientationUp];
+            CGImageRelease(cgImage);
+        }
+        CFRelease(imageSource);
+    }
+    return self;
+}
+
+- (CGImageAlphaInfo)alphaInfo {
+    return CGImageGetAlphaInfo(self.CGImage);
+}
+
+- (BOOL)writeToURL:(NSURL *)fileURL error:(NSError **)error {
+    NSString *imgType = _originalFileType;
+    if (nil == imgType) {
+        if (kCGImageAlphaFirst == self.alphaInfo ||
+            kCGImageAlphaLast == self.alphaInfo ||
+            kCGImageAlphaPremultipliedFirst == self.alphaInfo ||
+            kCGImageAlphaPremultipliedLast == self.alphaInfo) {
+            imgType = @"public.png";
+        } else {
+            imgType = @"public.jpeg";
+        }
+    }
+    if (2.f == self.scale) {
+        fileURL = [fileURL URLByAppendingPathExtension:@"@2x"];
+    }
+    CGImageDestinationRef imageDestination = CGImageDestinationCreateWithURL((__bridge CFURLRef)fileURL, (__bridge CFStringRef)imgType, 1, NULL);
+    if (NULL == imageDestination) {
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:-255 userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:@"[OGImageCache ERROR] failed to created image destination %s %d", __FILE__, __LINE__]}];
+        return NO;
+    }
+    CGImageDestinationAddImage(imageDestination, self.CGImage, (__bridge CFDictionaryRef)_originalFileProperties);
+    CGImageDestinationFinalize(imageDestination);
+    CFRelease(imageDestination);
+    return YES;
+}
+
+@end

--- a/OGImageDemo/OGImageDemo.xcodeproj/project.pbxproj
+++ b/OGImageDemo/OGImageDemo.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		C8392EB0169CA21700F0907A /* OGImageFileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C8392EAF169CA21700F0907A /* OGImageFileTests.m */; };
 		C8392EB2169CB38200F0907A /* OGImageAssetsLibraryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C8392EB1169CB38200F0907A /* OGImageAssetsLibraryTests.m */; };
 		C8392EB4169CB44800F0907A /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8392EB3169CB44800F0907A /* AssetsLibrary.framework */; };
+		C83BE57816C575CC00D82A1A /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C83BE57716C575CC00D82A1A /* ImageIO.framework */; };
+		C83BE57916C5775000D82A1A /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C83BE57716C575CC00D82A1A /* ImageIO.framework */; };
+		C83BE57E16C5904600D82A1A /* __OGImage.m in Sources */ = {isa = PBXBuildFile; fileRef = C83BE57D16C5904600D82A1A /* __OGImage.m */; };
+		C83BE57F16C5904600D82A1A /* __OGImage.m in Sources */ = {isa = PBXBuildFile; fileRef = C83BE57D16C5904600D82A1A /* __OGImage.m */; };
 		C84972B1166564D000DB15D1 /* OGImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C84972B0166564D000DB15D1 /* OGImageCache.m */; };
 		C862B470169CE88F00C674CF /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8392EB3169CB44800F0907A /* AssetsLibrary.framework */; };
 		C86E0BEC1667FE36006063B6 /* OGImageProcessing.m in Sources */ = {isa = PBXBuildFile; fileRef = C86E0BEB1667FE36006063B6 /* OGImageProcessing.m */; };
@@ -77,6 +81,9 @@
 		C8392EAF169CA21700F0907A /* OGImageFileTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OGImageFileTests.m; sourceTree = "<group>"; };
 		C8392EB1169CB38200F0907A /* OGImageAssetsLibraryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OGImageAssetsLibraryTests.m; sourceTree = "<group>"; };
 		C8392EB3169CB44800F0907A /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
+		C83BE57716C575CC00D82A1A /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
+		C83BE57C16C5904600D82A1A /* __OGImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = __OGImage.h; sourceTree = "<group>"; };
+		C83BE57D16C5904600D82A1A /* __OGImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = __OGImage.m; sourceTree = "<group>"; };
 		C84972AF166564D000DB15D1 /* OGImageCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = OGImageCache.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		C84972B0166564D000DB15D1 /* OGImageCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OGImageCache.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		C86E0BEA1667FE36006063B6 /* OGImageProcessing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = OGImageProcessing.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
@@ -126,6 +133,7 @@
 				C8392EB4169CB44800F0907A /* AssetsLibrary.framework in Frameworks */,
 				C871144316640E510015A743 /* CoreGraphics.framework in Frameworks */,
 				C871144216640E510015A743 /* Foundation.framework in Frameworks */,
+				C83BE57916C5775000D82A1A /* ImageIO.framework in Frameworks */,
 				C871145E16640F2E0015A743 /* libPods.a in Frameworks */,
 				C871144116640E510015A743 /* UIKit.framework in Frameworks */,
 			);
@@ -139,6 +147,7 @@
 				C862B470169CE88F00C674CF /* AssetsLibrary.framework in Frameworks */,
 				C882721D1663DBDF007D409F /* CoreGraphics.framework in Frameworks */,
 				C882721B1663DBDF007D409F /* Foundation.framework in Frameworks */,
+				C83BE57816C575CC00D82A1A /* ImageIO.framework in Frameworks */,
 				C88272191663DBDF007D409F /* UIKit.framework in Frameworks */,
 				416DC6759A8046D6AED27FFE /* libPods.a in Frameworks */,
 			);
@@ -222,6 +231,7 @@
 				C8392EB3169CB44800F0907A /* AssetsLibrary.framework */,
 				C882721C1663DBDF007D409F /* CoreGraphics.framework */,
 				C882721A1663DBDF007D409F /* Foundation.framework */,
+				C83BE57716C575CC00D82A1A /* ImageIO.framework */,
 				467479B3192A45B8984313B7 /* libPods.a */,
 				C88272181663DBDF007D409F /* UIKit.framework */,
 			);
@@ -276,6 +286,8 @@
 				C8975AE9166E09BB00C2D53A /* OGScaledImage.m */,
 				C808967A1694DFC0009BE21D /* OGImageRequest.h */,
 				C808967B1694DFC0009BE21D /* OGImageRequest.m */,
+				C83BE57C16C5904600D82A1A /* __OGImage.h */,
+				C83BE57D16C5904600D82A1A /* __OGImage.m */,
 			);
 			name = OGImage;
 			path = ../../OGImage;
@@ -413,6 +425,7 @@
 				C8392EB0169CA21700F0907A /* OGImageFileTests.m in Sources */,
 				C8392EB2169CB38200F0907A /* OGImageAssetsLibraryTests.m in Sources */,
 				C87C645F16C46C70006217C9 /* OGImageIdempotentTests.m in Sources */,
+				C83BE57F16C5904600D82A1A /* __OGImage.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -431,6 +444,7 @@
 				C86E0BEC1667FE36006063B6 /* OGImageProcessing.m in Sources */,
 				C8975AEA166E09BB00C2D53A /* OGScaledImage.m in Sources */,
 				C808967C1694DFC0009BE21D /* OGImageRequest.m in Sources */,
+				C83BE57E16C5904600D82A1A /* __OGImage.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OGImageDemo/OGImageDemo/OGViewController.m
+++ b/OGImageDemo/OGImageDemo/OGViewController.m
@@ -65,7 +65,7 @@
     }
     NSURL *imageURL = [NSURL URLWithString:_urls[indexPath.row]];
     CGFloat imageSide = self.tableView.rowHeight;
-    OGScaledImage *image = [[OGScaledImage alloc] initWithURL:imageURL size:CGSizeMake(imageSide, imageSide) cornerRadius:10.f method:OGImageProcessingScale_AspectFit key:[NSString stringWithFormat:@"Image-%03d", indexPath.row] placeholderImage:[UIImage imageNamed:@"placeholder"]];
+    OGScaledImage *image = [[OGScaledImage alloc] initWithURL:imageURL size:CGSizeMake(imageSide, imageSide) cornerRadius:0.f method:OGImageProcessingScale_AspectFill key:nil placeholderImage:[UIImage imageNamed:@"placeholder"]];
     cell.image = image;
     return cell;
 }

--- a/OGImageDemo/OGImageTests/OGImageProcessingTests.m
+++ b/OGImageDemo/OGImageTests/OGImageProcessingTests.m
@@ -96,8 +96,6 @@ static const CGSize TEST_SCALE_SIZE = {128.f, 128.f};
         }
         return;
     }
-    GHTestLog(@"Unexpected key change...");
-    [self notify:kGHUnitWaitStatusFailure];
 }
 
 - (void)testScaledImage1 {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ over HTTP in a simple, extensible interface.
         // we already have an image, so do whatever we need with it, otherwise
         // we'll be notified in `observeValueInKeyPath` whenever the image changes
         [self displayImage:ogImage.image];
+        // ooh, we also got all the image's metadata! Sweet!
+        NSDictionary *exifData = [ogImage.originalFileProperties valueForKey:kCGImagePropertyExifDictionary];
     }
     ```
 
@@ -45,11 +47,11 @@ over HTTP in a simple, extensible interface.
 To use OGImage in your projects, simply add the files in the `OGImage`
 subdirectory to your target.
 
-You'll need to add `AssetsLibrary.framework` to your target's "Link Binary With
-Libraries" build phase. If you're using `OGScaledImage` and/or
-`OGImageProcessing`, you'll additionally need to add `Accelerate.framework` and
-`AssetsLibrary.framework` to your target's "Link Binary With Libraries" build
-phase.
+You'll need to add `AssetsLibrary.framework` and `ImageIO.framework` to your
+target's "Link Binary With Libraries" build phase. If you're using
+`OGScaledImage` and/or `OGImageProcessing`, you'll additionally need to add
+`Accelerate.framework` and `AssetsLibrary.framework` to your target's "Link
+Binary With Libraries" build phase.
 
 ## Usage
 


### PR DESCRIPTION
We now use Image I/O to load—and, when caching, save—images. This makes it easy to track the original file type, alpha channel properties and even pass around the original image's metadata.
