### PR TITLE
Use KVO in a context-aware fashion.

### DIFF
--- a/OGImage/OGImage.h
+++ b/OGImage/OGImage.h
@@ -25,17 +25,17 @@
 
 /**
  * Convenience method: This is equivalent to calling
- *    [ogimg addObserver:observer forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:nil];
- *    [ogimg addObserver:observer forKeyPath:@"error" options:NSKeyValueObservingOptionNew context:nil];
+ *    [ogimg addObserver:observer forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:context];
+ *    [ogimg addObserver:observer forKeyPath:@"error" options:NSKeyValueObservingOptionNew context:context];
  */
-- (void)addObserver:(NSObject *)observer;
+- (void)addObserver:(NSObject *)observer context:(void *)context;
 
 /**
  * Convenience method: This is equivalent to calling
- *    [ogimg removeObserver:observer forKeyPath:@"image"];
- *    [ogimg removeObserver:observer forKeyPath:@"error"];
+ *    [ogimg removeObserver:observer forKeyPath:@"image" context:context];
+ *    [ogimg removeObserver:observer forKeyPath:@"error" context:context];
  */
-- (void)removeObserver:(NSObject *)observer;
+- (void)removeObserver:(NSObject *)observer context:(void *)context;
 
 /**
  * Subclasses can override this method to perform caching, processing, etc., but

--- a/OGImage/OGImage.m
+++ b/OGImage/OGImage.m
@@ -26,17 +26,17 @@
     return self;
 }
 
-- (void)addObserver:(NSObject *)observer {
-    [self addObserver:observer forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:nil];
-    [self addObserver:observer forKeyPath:@"error" options:NSKeyValueObservingOptionNew context:nil];
+- (void)addObserver:(NSObject *)observer context:(void *)context {
+    [self addObserver:observer forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:context];
+    [self addObserver:observer forKeyPath:@"error" options:NSKeyValueObservingOptionNew context:context];
 }
 
-- (void)removeObserver:(NSObject *)observer {
+- (void)removeObserver:(NSObject *)observer context:(void *)context {
     @try {
-        [self removeObserver:observer forKeyPath:@"image"];
+        [self removeObserver:observer forKeyPath:@"image" context:context];
     } @catch (NSException *e) {}
     @try {
-        [self removeObserver:observer forKeyPath:@"error"];
+        [self removeObserver:observer forKeyPath:@"error" context:context];
     } @catch (NSException *e) {}
 }
 

--- a/OGImage/OGScaledImage.h
+++ b/OGImage/OGScaledImage.h
@@ -49,11 +49,11 @@
 /**
  * Equivalent to adding an observer for @"image", @"scaledImage", & @"error"
  */
-- (void)addObserver:(NSObject *)observer;
+- (void)addObserver:(NSObject *)observer context:(void *)context;
 /**
  * Equivalent to removing an observer for @"image", @"scaledImage", & @"error"
  */
-- (void)removeObserver:(NSObject *)observer;
+- (void)removeObserver:(NSObject *)observer context:(void *)context;
 
 /**
  * The scaled image—The inherited `image` property is set to the full-size image at `url`.

--- a/OGImage/OGScaledImage.m
+++ b/OGImage/OGScaledImage.m
@@ -73,14 +73,14 @@ NSString *OGKeyWithSize(NSString *origKey, CGSize size, CGFloat cornerRadius) {
     return self;
 }
 
-- (void)addObserver:(NSObject *)observer {
-    [super addObserver:observer];
-    [self addObserver:observer forKeyPath:@"scaledImage" options:NSKeyValueObservingOptionNew context:nil];
+- (void)addObserver:(NSObject *)observer context:(void *)context {
+    [super addObserver:observer context:context];
+    [self addObserver:observer forKeyPath:@"scaledImage" options:NSKeyValueObservingOptionNew context:context];
 }
 
-- (void)removeObserver:(NSObject *)observer {
-    [super removeObserver:observer];
-    [self removeObserver:observer forKeyPath:@"scaledImage"];
+- (void)removeObserver:(NSObject *)observer context:(void *)context {
+    [super removeObserver:observer context:context];
+    [self removeObserver:observer forKeyPath:@"scaledImage" context:context];
 }
 
 - (void)loadImageFromURL {

--- a/OGImageDemo/OGImageTests/OGImageAsyncTests.m
+++ b/OGImageDemo/OGImageTests/OGImageAsyncTests.m
@@ -10,6 +10,8 @@
 #import "OGImage.h"
 #import "OGImageLoader.h"
 
+static NSString *KVOContext = @"OGImageAsyncTests observation";
+
 static NSString * const TEST_IMAGE_URL_STRING = @"http://easyquestion.net/thinkagain/wp-content/uploads/2009/05/james-bond.jpg";
 static NSString * const FAKE_IMAGE_URL_STRING = @"http://easyquestion.net/thinkagain/wp-content/uploads/2009/05/james00.jpg";
 static const CGSize TEST_IMAGE_SIZE = {317.f, 400.f};
@@ -22,26 +24,31 @@ static const CGSize TEST_IMAGE_SIZE = {317.f, 400.f};
 @implementation OGImage404Test
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
-    NSAssert(YES == [NSThread isMainThread], @"Expected `observeValueForKeyPath` to only be called on main thread");
-    if ([keyPath isEqualToString:@"error"]) {
-        OGImage *image = (OGImage *)object;
-        GHTestLog(@"Error changed: %@", image.error);
-        if (OGImageLoadingError == image.error.code) {
-            // we expect a loading error here
-            [self notify:kGHUnitWaitStatusSuccess];
-        } else {
-            [self notify:kGHUnitWaitStatusFailure];
+    if ((void *)&KVOContext == context) {
+        NSAssert(YES == [NSThread isMainThread], @"Expected `observeValueForKeyPath` to only be called on main thread");
+        if ([keyPath isEqualToString:@"error"]) {
+            OGImage *image = (OGImage *)object;
+            GHTestLog(@"Error changed: %@", image.error);
+            if (OGImageLoadingError == image.error.code) {
+                // we expect a loading error here
+                [self notify:kGHUnitWaitStatusSuccess];
+            } else {
+                [self notify:kGHUnitWaitStatusFailure];
+            }
+            return;
         }
-        return;
+    }
+    else {
+      [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     }
 }
 
 - (void)test404 {
     [self prepare];
     OGImage *image = [[OGImage alloc] initWithURL:[NSURL URLWithString:FAKE_IMAGE_URL_STRING]];
-    [image addObserver:self];
+    [image addObserver:self context:&KVOContext];
     [self waitForStatus:kGHUnitWaitStatusSuccess timeout:10.];
-    [image removeObserver:self];
+    [image removeObserver:self context:&KVOContext];
 }
 
 @end
@@ -54,27 +61,32 @@ static const CGSize TEST_IMAGE_SIZE = {317.f, 400.f};
 
 @implementation OGImageTest1
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
-    NSAssert(YES == [NSThread isMainThread], @"Expected `observeValueForKeyPath` to only be called on main thread");
-    if ([keyPath isEqualToString:@"image"]) {
-        OGImage *image = (OGImage *)object;
-        GHTestLog(@"Image loaded: %@ : %@", image.image, NSStringFromCGSize(image.image.size));
-        if (NO == CGSizeEqualToSize(image.image.size, TEST_IMAGE_SIZE)) {
-            [self notify:kGHUnitWaitStatusFailure];
-        } else {
-            [self notify:kGHUnitWaitStatusSuccess];
+    if ((void *)&KVOContext == context) {
+        NSAssert(YES == [NSThread isMainThread], @"Expected `observeValueForKeyPath` to only be called on main thread");
+        if ([keyPath isEqualToString:@"image"]) {
+            OGImage *image = (OGImage *)object;
+            GHTestLog(@"Image loaded: %@ : %@", image.image, NSStringFromCGSize(image.image.size));
+            if (NO == CGSizeEqualToSize(image.image.size, TEST_IMAGE_SIZE)) {
+                [self notify:kGHUnitWaitStatusFailure];
+            } else {
+                [self notify:kGHUnitWaitStatusSuccess];
+            }
+            return;
         }
-        return;
+        GHTestLog(@"Unexpected key change...");
+        [self notify:kGHUnitWaitStatusFailure];
     }
-    GHTestLog(@"Unexpected key change...");
-    [self notify:kGHUnitWaitStatusFailure];
+    else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
 }
 
 - (void)testImageOne {
     [self prepare];
     OGImage *image = [[OGImage alloc] initWithURL:[NSURL URLWithString:TEST_IMAGE_URL_STRING]];
-    [image addObserver:self forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:nil];
+    [image addObserver:self forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:&KVOContext];
     [self waitForStatus:kGHUnitWaitStatusSuccess timeout:10.];
-    [image removeObserver:self forKeyPath:@"image"];
+    [image removeObserver:self forKeyPath:@"image" context:&KVOContext];
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ over HTTP in a simple, extensible interface.
     /*
      * This is shorthand for calling KVO methods for @"image", @"scaledImage", and @"error"
      */
-    [ogImage addObserver:self];
+    [ogImage addObserver:self context:&KVOContext];
 
     // check to see if the image loaded instantly (e.g., from cache)
     if (nil != ogImage.image) {
         // we already have an image, so do whatever we need with it, otherwise
-        // we'll be notified in `observeValueInKeyPath` whenever the image changes
+        // we'll be notified in `observeValueForKeyPath:ofObject:change:context:` whenever the image changes
         [self displayImage:ogImage.image];
         // ooh, we also got all the image's metadata! Sweet!
         NSDictionary *exifData = [ogImage.originalFileProperties valueForKey:kCGImagePropertyExifDictionary];
@@ -66,16 +66,21 @@ placeholder image to use until loading is complete with
 ...
 
 OGImage *image = [[OGImage alloc] initWithURL:[NSURL URLWithString:@"http://somedomain.com/someimage.jpg"]];
-[image addObserver:self];
+[image addObserver:self context:&KVOContext];
 
 ...
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
-    if ([keyPath isEqualToString:@"image"]) {
-        // image was loaded!
-        ...
-    } else if ([keyPath isEqualToString:@"error"]) {
-        // error loading image
+    if ((void *)&KVOContext == context) {
+        if ([keyPath isEqualToString:@"image"]) {
+            // image was loaded!
+            ...
+        } else if ([keyPath isEqualToString:@"error"]) {
+            // error loading image
+        }
+    }
+    else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     }
 }
 ```
@@ -100,16 +105,20 @@ OGScaledImage *image = [[OGScaledImage alloc] initWithURL:imageURL size:scaledSi
  * Note that here we're interested in the `scaledImage` property, not the full-size `image`
  * property.
  */
-[image addObserver:self];
+[image addObserver:self context:&KVOContext];
 
 ...
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
-    if ([keyPath isEqualToString:@"scaledImage"]) {
-        // image was loaded and scaled!
-        ...
-    } else if ([keyPath isEqualToString:@"error"]) {
-        // error loading image
+    if ((void *)&KVOContext == context) {
+        if ([keyPath isEqualToString:@"scaledImage"]) {
+            // image was loaded and scaled!
+            ...
+        } else if ([keyPath isEqualToString:@"error"]) {
+            // error loading image
+        }
+    else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     }
 }
 ```


### PR DESCRIPTION
Small (but pervasive) changes to set a good example, and pay attention to the context when setting and using KVO.

The tests and the demo app use the addresses of static variables for their context pointers. References:
http://www.dribin.org/dave/blog/archives/2008/09/24/proper_kvo_usage/
http://stackoverflow.com/questions/12719864/best-practices-for-context-parameter-in-addobserver-kvo
