### PR TITLE
Date based cache purge

### DIFF
--- a/OGImage/OGImageCache.h
+++ b/OGImage/OGImageCache.h
@@ -46,5 +46,12 @@ typedef void (^OGImageCacheCompletionBlock)(__OGImage *image);
  */
 - (void)purgeMemoryCacheForKey:(NSString *)key andWait:(BOOL)wait;
 
+/**
+ * Remove cached images from disk that haven't been accessed since `date`
+ * If `wait` is `YES` this will block the calling thread until the purge
+ * is complete.
+ */
+- (void)purgeDiskCacheWithDate:(NSDate *)date wait:(BOOL)wait;
+
 
 @end

--- a/OGImage/OGImageCache.h
+++ b/OGImage/OGImageCache.h
@@ -19,6 +19,8 @@ typedef void (^OGImageCacheCompletionBlock)(__OGImage *image);
 
 + (NSString *)filePathForKey:(NSString *)key;
 
++ (NSURL *)fileURLForKey:(NSString *)key;
+
 /**
  * Check in-memory and on-disk caches for image corresponding to `key`. `block`
  * called on main queue when check is complete. If `image` parameter is `nil`,

--- a/OGImage/OGImageCache.h
+++ b/OGImage/OGImageCache.h
@@ -32,7 +32,9 @@ typedef void (^OGImageCacheCompletionBlock)(__OGImage *image);
 
 /**
  * Remove all cached images from in-memory and on-disk caches. If `wait` is `YES`
- * this will block the calling thread until the purge is complete.
+ * this will block the calling thread until the purge is complete. In either case,
+ * this method manages its own `UIBackgroundTaskIdentifier` — it's safe to call it
+ * from `applicationDidEnterBackground`
  */
 - (void)purgeCache:(BOOL)wait;
 
@@ -50,6 +52,8 @@ typedef void (^OGImageCacheCompletionBlock)(__OGImage *image);
 
 /**
  * Remove cached images from disk that haven't been accessed since `date`
+ * This method manages its own `UIBackgroundTaskIdentifier` — it's safe to call it
+ * from `applicationDidEnterBackground`
  */
 - (void)purgeDiskCacheOfImagesLastAccessedBefore:(NSDate *)date;
 

--- a/OGImage/OGImageCache.h
+++ b/OGImage/OGImageCache.h
@@ -19,6 +19,8 @@ typedef void (^OGImageCacheCompletionBlock)(__OGImage *image);
 
 + (NSString *)filePathForKey:(NSString *)key;
 
++ (NSURL *)fileURLForKey:(NSString *)key;
+
 /**
  * Check in-memory and on-disk caches for image corresponding to `key`. `block`
  * called on main queue when check is complete. If `image` parameter is `nil`,
@@ -45,10 +47,6 @@ typedef void (^OGImageCacheCompletionBlock)(__OGImage *image);
  * this will block the calling thread until the purge is complete.
  */
 - (void)purgeMemoryCacheForKey:(NSString *)key andWait:(BOOL)wait;
-
-/**
- *
- */
 
 /**
  * Remove cached images from disk that haven't been accessed since `date`

--- a/OGImage/OGImageCache.h
+++ b/OGImage/OGImageCache.h
@@ -47,11 +47,14 @@ typedef void (^OGImageCacheCompletionBlock)(__OGImage *image);
 - (void)purgeMemoryCacheForKey:(NSString *)key andWait:(BOOL)wait;
 
 /**
+ *
+ */
+
+/**
  * Remove cached images from disk that haven't been accessed since `date`
  * If `wait` is `YES` this will block the calling thread until the purge
  * is complete.
  */
-- (void)purgeDiskCacheWithDate:(NSDate *)date wait:(BOOL)wait;
-
+- (void)purgeDiskCacheOfImagesLastAccessedBefore:(NSDate *)date;
 
 @end

--- a/OGImage/OGImageCache.h
+++ b/OGImage/OGImageCache.h
@@ -50,8 +50,6 @@ typedef void (^OGImageCacheCompletionBlock)(__OGImage *image);
 
 /**
  * Remove cached images from disk that haven't been accessed since `date`
- * If `wait` is `YES` this will block the calling thread until the purge
- * is complete.
  */
 - (void)purgeDiskCacheOfImagesLastAccessedBefore:(NSDate *)date;
 

--- a/OGImage/OGImageCache.m
+++ b/OGImage/OGImageCache.m
@@ -63,7 +63,7 @@ NSURL *OGImageCacheURL() {
         _memoryCache = [[NSCache alloc] init];
         [_memoryCache setName:@"com.origamilabs.OGImageCache"];
         /*
-         * We use the 'queue-jumping' pattern outlined in WWDC 2012 Session 201: "Mastering Grand Central Dispatch"
+         * We use the 'queue-jumping' pattern outlined in WWDC 2011 Session 201: "Mastering Grand Central Dispatch"
          * We place lower-priority tasks (writing, purging) on a serial queue that has its
          * target queue set to our high-priority (read) queue. Whenever we submit a high-priority
          * block, we suspend the lower-priority queue for the duration of the block.

--- a/OGImageDemo/OGImageDemo/OGAppDelegate.m
+++ b/OGImageDemo/OGImageDemo/OGAppDelegate.m
@@ -10,6 +10,7 @@
 #import "OGViewController.h"
 #import "DDLog.h"
 #import "DDTTYLogger.h"
+#import "OGImageCache.h"
 
 @implementation OGAppDelegate
 
@@ -28,25 +29,22 @@
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later. 
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    // purge the disk cache of any image that hasn't been
+    // accessed more recently than 2 minutes ago. This is obviously pretty contrived;
+    NSDate *before = [NSDate dateWithTimeIntervalSinceNow:-120.];
+    [[OGImageCache shared] purgeDiskCacheOfImagesLastAccessedBefore:before];
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
-    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application {
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
 @end

--- a/OGImageDemo/OGImageDemo/OGImageTableViewCell.m
+++ b/OGImageDemo/OGImageDemo/OGImageTableViewCell.m
@@ -32,9 +32,11 @@ static NSString *KVOContext = @"OGImageTableViewCell observation";
         if ([keyPath isEqualToString:@"scaledImage"]) {
             self.imageView.image = self.image.scaledImage;
             self.textLabel.text = [[self.image.url path] lastPathComponent];
-            self.detailTextLabel.text = [NSString stringWithFormat:@"%.2f", self.image.loadTime];
         } else if ([keyPath isEqualToString:@"error"]) {
-            
+            self.detailTextLabel.textColor = [UIColor redColor];
+            self.detailTextLabel.text = [NSString stringWithFormat:NSLocalizedString(@"%@", @""), [self.image.error localizedDescription]];
+            self.imageView.image = self.image.scaledImage;
+            [self setNeedsLayout];
         }
     }
     else {
@@ -45,23 +47,20 @@ static NSString *KVOContext = @"OGImageTableViewCell observation";
 #pragma mark - Properties
 
 - (void)setImage:(OGScaledImage *)image {
+    self.detailTextLabel.text = @"";
     /*
      * When the cell's image is set, we want to first make sure we're no longer listening
      * for any KVO notifications on the cell's previous image.
      */
-    [_image removeObserver:self forKeyPath:@"error" context:&KVOContext];
-    [_image removeObserver:self forKeyPath:@"scaledImage" context:&KVOContext];
+    [_image removeObserver:self context:&KVOContext];
     _image = image;
-    self.imageView.image = _image.scaledImage;
+    [_image addObserver:self context:&KVOContext];
     self.textLabel.text = [[self.image.url path] lastPathComponent];
-    self.detailTextLabel.text = NSLocalizedString(@"Loading", @"");
-    [_image addObserver:self forKeyPath:@"error" options:NSKeyValueObservingOptionNew context:&KVOContext];
-    [_image addObserver:self forKeyPath:@"scaledImage" options:NSKeyValueObservingOptionNew context:&KVOContext];
+    self.imageView.image = _image.scaledImage;
 }
 
 - (void)dealloc {
-    [_image removeObserver:self forKeyPath:@"error" context:&KVOContext];
-    [_image removeObserver:self forKeyPath:@"scaledImage" context:&KVOContext];
+    [_image removeObserver:self context:&KVOContext];
 }
 
 @end

--- a/OGImageDemo/OGImageDemo/OGViewController.m
+++ b/OGImageDemo/OGImageDemo/OGViewController.m
@@ -8,6 +8,7 @@
 
 #import "OGViewController.h"
 #import "OGScaledImage.h"
+#import "OGImageCache.h"
 #import "OGImageTableViewCell.h"
 
 @interface OGViewController ()
@@ -20,8 +21,13 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    // purge the disk cache of any image that hasn't been
+    // accessed more recently than 2 minutes ago. This is pretty contrived;
+    // You'd probably do this in `application:didFinishLaunchingWithOptions:` or
+    // `applicationDidEnterBackground` or similar.
+    NSDate *since = [NSDate dateWithTimeIntervalSinceNow:-120.];
+    [[OGImageCache shared] purgeDiskCacheWithDate:since wait:YES];
     [self loadJSON];
-	// Do any additional setup after loading the view, typically from a nib.
 }
 
 - (void)didReceiveMemoryWarning {

--- a/OGImageDemo/OGImageDemo/OGViewController.m
+++ b/OGImageDemo/OGImageDemo/OGViewController.m
@@ -21,12 +21,6 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // purge the disk cache of any image that hasn't been
-    // accessed more recently than 2 minutes ago. This is pretty contrived;
-    // You'd probably do this in `application:didFinishLaunchingWithOptions:` or
-    // `applicationDidEnterBackground` or similar.
-    NSDate *since = [NSDate dateWithTimeIntervalSinceNow:-120.];
-    [[OGImageCache shared] purgeDiskCacheWithDate:since wait:YES];
     [self loadJSON];
 }
 


### PR DESCRIPTION
Provides a new method on `OGImageCache` : `purgeDiskCacheOfImagesLastAccessedBefore:`

This removes any cached files from disk whose access time is older than the provided date. Client apps can use this to implement LRU-based cache cleanup appropriate for their use cases.
